### PR TITLE
Apply expermental.patch fixes for v0.8.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(mdnsd)
+project(mdnsd_example)
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/tools/cmake")
 
 include(GNUInstallDirs)
@@ -15,11 +15,9 @@ if(MDNSD_BUILD_FUZZING)
     add_definitions(-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 endif()
 
-set(BUILD_SHARED_LIBS_DEFAULT ON)
 if(MDNSD_BUILD_OSS_FUZZ)
-    set(BUILD_SHARED_LIBS_DEFAULT OFF)
+    set(BUILD_SHARED_LIBS OFF)
 endif()
-option(BUILD_SHARED_LIBS "Build libmdnsd as a shared library" ${BUILD_SHARED_LIBS_DEFAULT})
 
 if(MDNSD_BUILD_FUZZING_CORPUS)
     add_definitions(-DMDNSD_DEBUG_DUMP_PKGS_FILE)
@@ -51,13 +49,13 @@ if(MDNSD_BUILD_FUZZING OR MDNSD_BUILD_OSS_FUZZ)
     add_subdirectory(tests/fuzz)
 endif()
 
-add_executable(mdnsd mdnsd.c)
-target_link_libraries(mdnsd PRIVATE libmdnsd)
+add_executable(mdns_daemon mdnsd.c)
+target_link_libraries(mdns_daemon PRIVATE mdnsd)
 
 add_executable(mquery mquery.c)
-target_link_libraries(mquery PRIVATE libmdnsd)
+target_link_libraries(mquery PRIVATE mdnsd)
 
-install(TARGETS mdnsd mquery
+install(TARGETS mdns_daemon mquery
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
 )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,5 +75,5 @@ build_script:
   - cd build
   - echo "Testing %CC_NAME%"
   - cmake -DMDNSD_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -G"%CC_NAME%" ..
-  - cmake --build . --config '%TARGET%' --target all
+  - cmake --build . --config '%TARGET%'
   - echo "Build done"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,37 +15,16 @@ environment:
     matrix:
         - CC_NAME: MinGW Makefiles
           CC_SHORTNAME: mingw
-          TARGET: Release
-          FORCE_CXX: OFF
-        - CC_NAME: MinGW Makefiles
-          CC_SHORTNAME: mingw
-          TARGET: Debug
           FORCE_CXX: OFF
         - CC_NAME: Visual Studio 9 2008
           CC_SHORTNAME: vs2008
-          TARGET: Release
-          FORCE_CXX: ON
-        - CC_NAME: Visual Studio 9 2008
-          CC_SHORTNAME: vs2008
-          TARGET: Debug
           FORCE_CXX: ON
         - CC_NAME: Visual Studio 12 2013
           CC_SHORTNAME: vs2013
-          TARGET: Release
-          FORCE_CXX: OFF
-        - CC_NAME: Visual Studio 12 2013
-          CC_SHORTNAME: vs2013
-          TARGET: Debug
           FORCE_CXX: OFF
         - CC_NAME: Visual Studio 12 2013 Win64
           CC_SHORTNAME: vs2013-x64
-          TARGET: Release
           FORCE_CXX: OFF
-        - CC_NAME: Visual Studio 12 2013 Win64
-          CC_SHORTNAME: vs2013-x64
-          TARGET: Debug
-          FORCE_CXX: OFF
-
 
 cache:
   - '%CYG_CACHE%'
@@ -75,5 +54,5 @@ build_script:
   - cd build
   - echo "Testing %CC_NAME%"
   - cmake -DMDNSD_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -G"%CC_NAME%" ..
-  - cmake --build . --config '%TARGET%'
+  - cmake --build .
   - echo "Build done"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,5 +75,5 @@ build_script:
   - cd build
   - echo "Testing %CC_NAME%"
   - cmake -DMDNSD_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -G"%CC_NAME%" ..
-  - cmake --build ./build --config '%TARGET%' --target all --
+  - cmake --build . --config '%TARGET%' --target all --
   - echo "Build done"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,19 +15,35 @@ environment:
     matrix:
         - CC_NAME: MinGW Makefiles
           CC_SHORTNAME: mingw
-          MAKE: mingw32-make
+          TARGET: Release
+          FORCE_CXX: OFF
+        - CC_NAME: MinGW Makefiles
+          CC_SHORTNAME: mingw
+          TARGET: Debug
           FORCE_CXX: OFF
         - CC_NAME: Visual Studio 9 2008
           CC_SHORTNAME: vs2008
-          MAKE: msbuild mdnsd.sln /m
+          TARGET: Release
+          FORCE_CXX: ON
+        - CC_NAME: Visual Studio 9 2008
+          CC_SHORTNAME: vs2008
+          TARGET: Debug
           FORCE_CXX: ON
         - CC_NAME: Visual Studio 12 2013
           CC_SHORTNAME: vs2013
-          MAKE: msbuild mdnsd.sln /m
+          TARGET: Release
+          FORCE_CXX: OFF
+        - CC_NAME: Visual Studio 12 2013
+          CC_SHORTNAME: vs2013
+          TARGET: Debug
           FORCE_CXX: OFF
         - CC_NAME: Visual Studio 12 2013 Win64
           CC_SHORTNAME: vs2013-x64
-          MAKE: msbuild mdnsd.sln /m
+          TARGET: Release
+          FORCE_CXX: OFF
+        - CC_NAME: Visual Studio 12 2013 Win64
+          CC_SHORTNAME: vs2013-x64
+          TARGET: Debug
           FORCE_CXX: OFF
 
 
@@ -59,5 +75,5 @@ build_script:
   - cd build
   - echo "Testing %CC_NAME%"
   - cmake -DMDNSD_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -G"%CC_NAME%" ..
-  - '%MAKE%'
+  - cmake --build ./build --config '%TARGET%' --target all --
   - echo "Build done"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,5 +75,5 @@ build_script:
   - cd build
   - echo "Testing %CC_NAME%"
   - cmake -DMDNSD_COMPILE_AS_CXX:BOOL=%FORCE_CXX% -G"%CC_NAME%" ..
-  - cmake --build . --config '%TARGET%' --target all --
+  - cmake --build . --config '%TARGET%' --target all
   - echo "Build done"

--- a/libmdnsd/CMakeLists.txt
+++ b/libmdnsd/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(libmdnsd)
+project(mdnsd)
 
 set(MDNSD_LOGLEVEL 300 CACHE STRING "Level at which logs shall be reported")
 
@@ -48,10 +48,7 @@ if(BUILD_SHARED_LIBS)
   set(MDNSD_DYNAMIC_LINKING ON)
 endif()
 
-configure_file("mdnsd_config.h.in" "${PROJECT_BINARY_DIR}/mdnsd_config.h")
-include_directories(${PROJECT_BINARY_DIR})
-
-set(PUBLIC_INCLUDES mdnsd.h 1035.h sdtxt.h xht.h)
+set(PUBLIC_INCLUDES mdnsd.h 1035.h sdtxt.h xht.h mdnsd_config.h)
 if(CMAKE_C_COMPILER_ID MATCHES MSVC)
   list(APPEND PUBLIC_INCLUDES ms_stdint.h)
 endif()
@@ -71,12 +68,15 @@ if(MDNSD_COMPILE_AS_CXX)
     set_source_files_properties(${LIBRARY_FILES} PROPERTIES LANGUAGE CXX)
 endif()
 
-add_library(libmdnsd ${LIBRARY_FILES} ${PUBLIC_INCLUDES})
-set_property(TARGET libmdnsd PROPERTY OUTPUT_NAME "mdnsd")
-set_property(TARGET libmdnsd PROPERTY DEFINE_SYMBOL "MDNSD_DYNAMIC_LINKING_EXPORT")
+add_compile_definitions(MDNSD_LOGLEVEL=${MDNSD_LOGLEVEL})
+
+add_library(${PROJECT_NAME} ${LIBRARY_FILES} ${PUBLIC_INCLUDES})
+if(MDNSD_DYNAMIC_LINKING)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC MDNSD_DYNAMIC_LINKING_EXPORT)
+endif()
 
 if(WIN32)
-  target_link_libraries(libmdnsd PUBLIC wsock32 ws2_32)
+  target_link_libraries(${PROJECT_NAME} PUBLIC wsock32 ws2_32)
 endif()
 
 install(
@@ -88,10 +88,5 @@ install(
 
 install(
     FILES ${PUBLIC_INCLUDES}
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"
-)
-
-install(
-    FILES ${PROJECT_BINARY_DIR}/mdnsd_config.h
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/lib${PROJECT_NAME}"
 )

--- a/libmdnsd/mdnsd_config.h
+++ b/libmdnsd/mdnsd_config.h
@@ -22,27 +22,26 @@
 #define MDNSD_calloc(num, size) calloc(num, size)
 #define MDNSD_realloc(ptr, size) realloc(ptr, size)
 
-#define MDNSD_LOGLEVEL ${MDNSD_LOGLEVEL}
-
 /**
  * Function Export
  * --------------- */
 /* On Win32: Define MDNSD_DYNAMIC_LINKING and MDNSD_DYNAMIC_LINKING_EXPORT in order to
    export symbols for a DLL. Define MDNSD_DYNAMIC_LINKING only to import symbols
 	from a DLL.*/
-#cmakedefine MDNSD_DYNAMIC_LINKING
-#ifdef _WIN32
-# ifdef MDNSD_DYNAMIC_LINKING_EXPORT
-#  ifdef __GNUC__
-#   define MDNSD_EXPORT __attribute__ ((dllexport))
+#ifdef MDNSD_DYNAMIC_LINKING
+# ifdef _WIN32
+#  ifdef MDNSD_DYNAMIC_LINKING_EXPORT
+#   ifdef __GNUC__
+#    define MDNSD_EXPORT __attribute__ ((dllexport))
+#   else
+#    define MDNSD_EXPORT __declspec(dllexport)
+#   endif
 #  else
-#   define MDNSD_EXPORT __declspec(dllexport)
-#  endif
-# else
-#  ifdef __GNUC__
-#   define MDNSD_EXPORT __attribute__ ((dllexport))
-#  else
-#   define MDNSD_EXPORT __declspec(dllimport)
+#   ifdef __GNUC__
+#    define MDNSD_EXPORT __attribute__ ((dllexport))
+#   else
+#    define MDNSD_EXPORT __declspec(dllimport)
+#   endif
 #  endif
 # endif
 #else


### PR DESCRIPTION
This PR is based on various CI reports form [conan-central-index](https://github.com/conan-io/conan-center-index/pull/2009). These changes include: 

Root CMakeLists.txt
* change `mdnsd -> mdnsd_example` and `mdnsd  -> mdns_daemon` to avoid name collision on windows systems, solves errors in [CMake.log](https://c3i.jfrog.io/c3i/misc/logs/pr/2009/19/pro-mdnsd/0.8.3/f27dcd2d5e453cb01f9324a959461903ce8116a0/create_stdout.txt)
* remove `BUILD_SHARED_LIBS_DEFAULT` option, since `BUILD_SHARED_LIBS` is enought on it's own


libmdnsd CMakeLists.txt
* `set_property -> target_compile_definitions` to properly set windows export symbols, solves errors in [CMake.log](https://c3i.jfrog.io/c3i/misc/logs/pr/2009/18/pro-mdnsd/0.8.3/f27dcd2d5e453cb01f9324a959461903ce8116a0/create_stdout.txt)
* rework `mdnsd_config.h.in` into `mdnsd_config.h`, solves msvc 15 not compiling **.lib** file for the **.dll** when `shared=True`, solves erros in [CMake.log](https://c3i.jfrog.io/c3i/misc/logs/pr/2009/33/pro-mdnsd/0.8.3/ff82a1e70ba8430648a79986385b20a3648f8c19/create_stdout.txt) 
* moved `MDNSD_LOGLEVEL` definition from  `mdnsd_config.h` into **CMakeLists.txt**
* changed project name `libmdnsd -> mdnsd`
* changed target names to use the project name
* changed include directory install location to `${CMAKE_INSTALL_INCLUDEDIR}/lib${PROJECT_NAME}` to support include path `libmdnsnd/*`