### PR TITLE
Devel/ipv6

### DIFF
--- a/libmdnsd/1035.c
+++ b/libmdnsd/1035.c
@@ -368,6 +368,23 @@ static bool _rrparse(struct message *m, struct resource *rr, int count, const un
             *bufp += 4;
 			break;
 
+		case QTYPE_AAAA:
+			if (m->_len + INET6_ADDRSTRLEN > MAX_PACKET_LEN) {
+				return false;
+			}
+			rr[i].known.aaaa.name = (char *)m->_packet + m->_len;
+			m->_len += INET6_ADDRSTRLEN;
+			if (*bufp + rr->rdlength > bufferEnd) {
+				return false;
+			}
+			addr_bytes = (const unsigned char *)*bufp;
+			inet_ntop(AF_INET6,addr_bytes,rr[i].known.aaaa.name,INET6_ADDRSTRLEN);
+			for (size_t j = 0; j < rr->rdlength; j++) {
+				rr[i].known.aaaa.ip6.s6_addr[j] = addr_bytes[j];
+			}
+			*bufp += rr->rdlength;
+			break;
+
 		case QTYPE_NS:
 			if (!_label(m, bufp, bufferEnd, &(rr[i].known.ns.name))) {
                 return false;

--- a/libmdnsd/1035.h
+++ b/libmdnsd/1035.h
@@ -72,6 +72,7 @@ struct question {
 #define QTYPE_CNAME  5
 #define QTYPE_PTR    12
 #define QTYPE_TXT    16
+#define QTYPE_AAAA   28
 #define QTYPE_SRV    33
 
 struct resource {

--- a/libmdnsd/1035.h
+++ b/libmdnsd/1035.h
@@ -88,6 +88,11 @@ struct resource {
 			char *name;
 		} a;
 		struct {
+			struct in6_addr ip6;
+			//cppcheck-suppress unusedStructMember
+			char *name;
+		} aaaa;
+		struct {
 			//cppcheck-suppress unusedStructMember
 			char *name;
 		} ns;

--- a/libmdnsd/mdnsd.c
+++ b/libmdnsd/mdnsd.c
@@ -492,6 +492,10 @@ static int _cache(mdns_daemon_t *d, struct resource *r)
 	}
 
 	switch (r->type) {
+		case QTYPE_AAAA:
+			c->rr.ip6 = r->known.aaaa.ip6;
+		break;
+
 		case QTYPE_A:
 			c->rr.ip = r->known.a.ip;
 			break;

--- a/libmdnsd/mdnsd.h
+++ b/libmdnsd/mdnsd.h
@@ -125,7 +125,7 @@ void MDNSD_EXPORT mdnsd_register_receive_callback(mdns_daemon_t *d, mdnsd_record
 /**
  * Oncoming message from host (to be cached/processed)
  */
-int MDNSD_EXPORT mdnsd_in(mdns_daemon_t *d, struct message *m, in_addr_t ip, unsigned short int port);
+int MDNSD_EXPORT mdnsd_in(mdns_daemon_t *d, struct message *m, struct sockaddr *ip, unsigned short int port);
 
 /**
  * Outgoing messge to be delivered to host, returns >0 if one was

--- a/libmdnsd/mdnsd.h
+++ b/libmdnsd/mdnsd.h
@@ -131,7 +131,7 @@ int MDNSD_EXPORT mdnsd_in(mdns_daemon_t *d, struct message *m, struct sockaddr *
  * Outgoing messge to be delivered to host, returns >0 if one was
  * returned and m/ip/port set
  */
-int MDNSD_EXPORT mdnsd_out(mdns_daemon_t *d, struct message *m, struct in_addr *ip, unsigned short int *port);
+int MDNSD_EXPORT mdnsd_out(mdns_daemon_t *d, struct message *m, struct sockaddr *ip, unsigned short int *port);
 
 /**
  * returns the max wait-time until mdnsd_out() needs to be called again 

--- a/libmdnsd/mdnsd.h
+++ b/libmdnsd/mdnsd.h
@@ -78,6 +78,7 @@ typedef struct mdns_answer {
 	unsigned short rdlen;
 	unsigned char *rdata;
 	struct in_addr ip;	/* A */
+	struct in6_addr ip6;	/* AAAA */
 	char *rdname;		/* NS/CNAME/PTR/SRV */
 	struct {
 		//cppcheck-suppress unusedStructMember


### PR DESCRIPTION
It adds the support for ipv6 in mdnsd (#27). 

- [x] Add QTYPE_AAAA record macro
- [x] Add parsing and caching of received IPV6 records
- [x] Creating ipv6 socket to join "ff02::fb" network.