### PR TITLE
fix(test): replace in_addr_t with sockaddr_storage in fuzz tests

### DIFF
--- a/tests/fuzz/fuzz_mdns_message.cc
+++ b/tests/fuzz/fuzz_mdns_message.cc
@@ -56,8 +56,8 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     mdns_daemon_t *d = mdnsd_new(QCLASS_IN, 1000);
 
-    in_addr_t addr = 0;
-    mdnsd_in(d, &m, addr, 2000);
+    struct sockaddr_storage addr;
+    mdnsd_in(d, &m, (struct sockaddr *)&addr, 2000);
 
     mdnsd_free(d);
 


### PR DESCRIPTION
the mdnsd_in now takes sockaddr_storage type for the socket address. This was causing build failures for fuzz testing in open62541 when bumped to the latest head.

Signed-off-by: Muddasir Shakil <muddasir.shakil@linutronix.de>